### PR TITLE
Add Persian and some few changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Convert Numbers to Words in Laravel
 
-Easily convert numbers to words in Laravel using this library, which supports the native PHP INTL extension to perform the conversion seamlessly. This library allows you to convert numbers to words in multiple languages and also get the value in currency format based on the selected language. Supported languages include English, Spanish, Portuguese, French, Italian, and Romanian.
+Easily convert numbers to words in Laravel using this library, which supports the native PHP INTL extension to perform the conversion seamlessly. This library allows you to convert numbers to words in multiple languages and also get the value in currency format based on the selected language. Supported languages include English, Spanish, Portuguese, French, Italian, Romanian, and Persian.
 
 ⚙️ This library is compatible with Laravel versions 8.0 and higher ⚙️
 
@@ -38,6 +38,7 @@ SpellNumber::getAllLocales();
 //     3 => "fr"
 //     4 => "it"
 //     5 => "ro"
+//     6 => "fa"
 // ]
 
 // CONVERT INTEGER TO WORDS

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-intl": "*",
         "illuminate/support": "^8.0|^9.0|^10.0"
     },

--- a/src/Langs/Langs.php
+++ b/src/Langs/Langs.php
@@ -18,6 +18,7 @@ final class Langs
         'fr',    // French from France
         'it',    // Italian from Italy
         'ro',    // Romanian from Romania
+        'fa',    // Farsi from Iran
     ];
 
     /**
@@ -32,6 +33,7 @@ final class Langs
         'fr' => 'et',    // French from France: "et"
         'it' => 'con',   // Italian from Italy: "con"
         'ro' => 'cu',    // Romanian from Romania: "cu"
+        'fa' => 'ممیز',     // Farsi from Iran: "ممیز"
     ];
 
     /**
@@ -46,15 +48,14 @@ final class Langs
         'fr' => 'de',    // French from France: "de"
         'it' => 'di',   // Italian from Italy: "di"
         'ro' => 'de',    // Romanian from Romania: "de"
+        'fa' => 'از',     // Farsi from Iran: "از"
     ];
 
     /**
      * Get the language locale used in Laravel application.
      * If the locale is supported in ISO 639-1 format, return it. Otherwise, return the default.
-     *
-     * @return string
      */
-    public static function getLocaleLaravel()
+    public static function getLocaleLaravel(): string
     {
         $localeLaravel = App::getLocale();
         $iso639_1 = substr($localeLaravel, 0, 2);

--- a/src/Miscellaneous/Replaces.php
+++ b/src/Miscellaneous/Replaces.php
@@ -42,6 +42,9 @@ final class Replaces
             'ilion'   => 'ilion De',
             'ilioane' => 'ilioane De',
         ],
+        'fa' => [
+            'ilion'   => 'میلیون و',
+        ],
     ];
 
     /**

--- a/src/SpellNumber.php
+++ b/src/SpellNumber.php
@@ -24,10 +24,10 @@ class SpellNumber extends BaseSpellNumber
     public const FRACTION = 'Centavos';
 
     private $value;
-    private $type;
-    protected $locale;
-    protected $currency;
-    protected $fraction;
+    private string $type;
+    protected string $locale;
+    protected string $currency;
+    protected string $fraction;
 
     /**
      * Constructor.
@@ -35,7 +35,7 @@ class SpellNumber extends BaseSpellNumber
      * @param mixed  $value The numeric value to convert to words.
      * @param string $type  The type of the value ('integer' or 'double').
      */
-    public function __construct($value, $type)
+    public function __construct($value, string $type)
     {
         $this->value = $value;
         $this->type = $type;

--- a/src/Validator/SpellNumberValidator.php
+++ b/src/Validator/SpellNumberValidator.php
@@ -3,6 +3,7 @@
 namespace Rmunate\Utilities\Validator;
 
 use Rmunate\Utilities\Bases\BaseSpellNumberValidator;
+use Rmunate\Utilities\Exceptions\SpellNumberExceptions;
 use Rmunate\Utilities\Validator\Traits\CommonValidate;
 
 final class SpellNumberValidator extends BaseSpellNumberValidator
@@ -17,8 +18,9 @@ final class SpellNumberValidator extends BaseSpellNumberValidator
     /**
      * Create a new instance of the SpellNumberValidator.
      *
-     * @param string $type  The type of data to validate (e.g., "mixed", "integer", "float").
-     * @param mixed  $value The value to validate.
+     * @param string $type The type of data to validate (e.g., "mixed", "integer", "float").
+     * @param mixed $value The value to validate.
+     * @throws SpellNumberExceptions
      */
     public function __construct(string $type, $value)
     {
@@ -40,11 +42,12 @@ final class SpellNumberValidator extends BaseSpellNumberValidator
      * Validate when the type is "mixed".
      *
      * @return $this
+     * @throws SpellNumberExceptions
      */
     public function mixed()
     {
         $this->validateNumeric();
-        $this->validateMaximun();
+        $this->validateMaximum();
         $this->response = $this->validateType();
 
         return $this;
@@ -54,11 +57,12 @@ final class SpellNumberValidator extends BaseSpellNumberValidator
      * Validate when the type is "integer".
      *
      * @return $this
+     * @throws SpellNumberExceptions
      */
     public function integer()
     {
         $this->validateInteger();
-        $this->response = $this->validateMaximun();
+        $this->response = $this->validateMaximum();
 
         return $this;
     }
@@ -67,11 +71,12 @@ final class SpellNumberValidator extends BaseSpellNumberValidator
      * Validate when the type is "float".
      *
      * @return $this
+     * @throws SpellNumberExceptions
      */
     public function float()
     {
         $this->validateString();
-        $this->response = $this->validateMaximun();
+        $this->response = $this->validateMaximum();
 
         return $this;
     }
@@ -81,7 +86,7 @@ final class SpellNumberValidator extends BaseSpellNumberValidator
      *
      * @return mixed The result of the validation.
      */
-    public function result()
+    public function result(): mixed
     {
         return $this->response;
     }

--- a/src/Validator/Traits/CommonValidate.php
+++ b/src/Validator/Traits/CommonValidate.php
@@ -11,10 +11,8 @@ trait CommonValidate
      * Validate that the "Intl" extension is loaded.
      *
      * @throws SpellNumberExceptions If the "Intl" extension is not installed or not available.
-     *
-     * @return bool
      */
-    private function validateExtension()
+    private function validateExtension(): bool
     {
         // Check if the intl extension is installed.
         if (!Utilities::validateExtension('Intl')) {
@@ -28,10 +26,8 @@ trait CommonValidate
      * Validate if the value is numeric.
      *
      * @throws SpellNumberExceptions If the supplied value is not valid (not integer or float).
-     *
-     * @return bool
      */
-    private function validateNumeric()
+    private function validateNumeric(): bool
     {
         if (!Utilities::isValidNumber($this->value)) {
             throw SpellNumberExceptions::create('The supplied value is not valid. It must be of type integer or float (double).');
@@ -44,10 +40,8 @@ trait CommonValidate
      * Validate if the value is an integer.
      *
      * @throws SpellNumberExceptions If the supplied value is not a valid integer.
-     *
-     * @return bool
      */
-    private function validateInteger()
+    private function validateInteger(): bool
     {
         if (!Utilities::isValidInteger($this->value)) {
             throw SpellNumberExceptions::create('The supplied value is not valid. It must be of type integer.');
@@ -60,10 +54,8 @@ trait CommonValidate
      * Validate if the value is a string.
      *
      * @throws SpellNumberExceptions If the supplied value is not a valid string.
-     *
-     * @return bool
      */
-    private function validateString()
+    private function validateString(): bool
     {
         if (!Utilities::isValidString($this->value)) {
             throw SpellNumberExceptions::create('The supplied value is not valid. It must be of type String.');
@@ -76,10 +68,8 @@ trait CommonValidate
      * Validate if the value does not exceed the maximum allowed value.
      *
      * @throws SpellNumberExceptions If the entered value exceeds the maximum allowed value.
-     *
-     * @return bool
      */
-    private function validateMaximun()
+    private function validateMaximum(): bool
     {
         if (!Utilities::isNotExceedMax($this->value)) {
             throw SpellNumberExceptions::create('The value entered is too large and has been converted to scientific notation which prevents processing.');
@@ -93,7 +83,7 @@ trait CommonValidate
      *
      * @return string Returns "integer" if the value is a valid integer, otherwise "double".
      */
-    private function validateType()
+    private function validateType(): string
     {
         return Utilities::isValidInteger($this->value) ? 'integer' : 'double';
     }

--- a/src/Wrappers/NumberFormatterWrapper.php
+++ b/src/Wrappers/NumberFormatterWrapper.php
@@ -14,12 +14,12 @@ final class NumberFormatterWrapper
     /**
      * Format a given numeric value as a spelled-out string.
      *
-     * @param float|int $value  The numeric value to format.
-     * @param string    $locale The locale used for formatting the number. Optional.
+     * @param float|int $value The numeric value to format.
+     * @param string|null $locale The locale used for formatting the number. Optional.
      *
      * @return string|null The spelled-out representation of the number, or null on failure.
      */
-    public static function format($value, string $locale = null)
+    public static function format(float|int $value, string $locale = null): ?string
     {
         // If no locale is provided, use the default locale from the environment.
         $locale = $locale ?: Langs::getLocaleLaravel();


### PR DESCRIPTION
1: Add Persian to the List of supported languages.
```php
SpellNumber::value(100)->locale('fa')->toLetters();
//صد

SpellNumber::value(100)->locale('fa')->currency('تومان')->toMoney();
//صد تومان
```

2: Remove PHP 7.4 since this is only usable for PHP 8.0 and higher.
since ```match``` is required PHP 8.0 and higher and is used in the files, So, I removed PHP 7.4 from ```composer.json``` because this will throw error in PHP < 8.0

3: add return type for methods.

4: rename method validateMaximun to validateMaximum and replace it in all files.
there was a method with ```validateMaximun``` name and I assume this was unwanted, so I renamed to ```validateMaximum```