### PR TITLE
3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 - Email: raulmauriciounate@gmail.com
 
 ## Contributors
-Farsi language:
-
-<img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Profile Image" width="30" style="border-radius: 50%;">[Siros Fakhri](https://github.com/sirosfakhri)
+<a href="https://github.com/sirosfakhri">
+    <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="40" height="40" style="border-radius: 50%;">
+</a>
+[Siros Fakhri](https://github.com/sirosfakhri)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Convert Numbers to Words in Laravel
 
-Easily convert numbers to words in Laravel using this library, which supports the native PHP INTL extension to perform the conversion seamlessly. This library allows you to convert numbers to words in multiple languages and also get the value in currency format based on the selected language. Supported languages include English, Spanish, Portuguese, French, Italian, Romanian, and Persian.
+Easily convert numbers to words in Laravel using this library, which leverages the native `PHP INTL` extension to perform conversion effortlessly. With this library, you can convert numbers to words in various languages and also obtain the value in currency format according to the selected language. Supported languages include English, Spanish, Portuguese, French, Italian, Romanian, and with the contribution of [Siros Fakhri](https://github.com/sirosfakhri), Persian (Farsi) support has been added.
 
 ⚙️ This library is compatible with Laravel versions 8.0 and higher ⚙️
 
@@ -11,64 +11,105 @@ Easily convert numbers to words in Laravel using this library, which supports th
 ![SpellNumbers](https://github.com/rmunate/SpellNumber/assets/91748598/f2aea68b-fc9f-46be-ae54-a4955f0ce7a2)
 
 ## Table of Contents
+
 - [Installation](#installation)
 - [Usage](#usage)
 - [Creator](#creator)
+- [Contributors](#contributors)
 - [License](#license)
 
 ## Installation
+
 To install the dependency via Composer, execute the following command:
 
 ```shell
 composer require rmunate/spell-number
 ```
 
-Make sure that the `intl` extension is enabled and loaded in your environment.
+It's important to ensure that the `intl` extension is enabled and loaded in the environment.
 
 ## Usage
+
 After installing the dependency in your project, you can start using it with the following examples:
 
-```php
-// GET AVAILABLE LOCALES
-SpellNumber::getAllLocales();
-// array:6 [▼ //
-//     0 => "en"
-//     1 => "es"
-//     2 => "pt"
-//     3 => "fr"
-//     4 => "it"
-//     5 => "ro"
-//     6 => "fa"
-// ]
+#### Knowing Supported Regional Configurations
 
-// CONVERT INTEGER TO WORDS
+To obtain the current list of languages with support, execute the following command:
+
+```php
+SpellNumber::getAllLocales();
+// array:7 [▼
+//     0 => "en" (English)
+//     1 => "es" (Spanish)
+//     2 => "pt" (Portuguese)
+//     3 => "fr" (French)
+//     4 => "it" (Italian)
+//     5 => "ro" (Romanian)
+//     6 => "fa" (Farsi)
+// ]
+```
+
+#### Convert Integers to Words
+
+You can easily convert numbers to words by defining the regional configuration to apply. If you don't define a regional configuration, "en" (English) will be applied by default.
+
+```php
+SpellNumber::value(100)->locale('es')->toLetters();
+// "Cien"
+
+SpellNumber::value(100)->locale('fa')->toLetters();
+// "صد"
+
 SpellNumber::value(100)->locale('en')->toLetters();
 // "One Hundred"
-SpellNumber::value(12300000)->locale('en')->toLetters();
-// "Twelve Million Three Hundred Thousand"
+```
 
-// CONVERT FLOAT TO WORDS
-SpellNumber::value(123456789.12)->locale('en')->toLetters();
-// "One Hundred Twenty-Three Million Four Hundred Fifty-Six Thousand Seven Hundred Eighty-Nine Point Twelve"
+#### Convert Floating-Point Numbers
 
-// CONVERT INTEGER TO CURRENCY TEXT FORMAT
-SpellNumber::value(100)->locale('en')->currency('dollars')->toMoney();
-// "One Hundred Dollars"
-SpellNumber::value(100.12)->locale('en')->currency('Dollars')->fraction('cents')->toMoney();
-// "One Hundred Dollars and Twelve Cents"
+If needed, you can pass a floating-point number as an argument to convert it to words.
 
-// OTHER STARTING METHODS
+```php
+SpellNumber::value(123456789.12)->locale('es')->toLetters();
+// "Ciento Veintitrés Millones Cuatrocientos Cincuenta Y Seis Mil Setecientos Ochenta Y Nueve Con Doce"
+```
 
-// Integer, this method strictly requires an integer value as an argument.
-SpellNumber::integer(100)->locale('en')->toLetters();
+#### Convert to Currency Format
 
-// Floats, this method strictly requires a string value as an argument.
-SpellNumber::float('12345.23')->locale('en')->toLetters();
+This method can be useful for invoices, receipts, and similar scenarios. Obtain the supplied value in currency format.
+
+```php
+SpellNumber::value(100)->locale('es')->currency('pesos')->toMoney();
+// "Cien Pesos"
+
+SpellNumber::value(100.12)->locale('es')->currency('Pesos')->fraction('centavos')->toMoney();
+// "Cien Pesos Con Doce Centavos"
+
+SpellNumber::value(100)->locale('fa')->currency('تومان')->toMoney();
+// "صد تومان"
+```
+
+#### Other Initializer Methods
+
+To support version 1.X, the following initializer methods are maintained.
+
+```php
+// Integer, this method strictly requires an integer value to be sent as an argument.
+SpellNumber::integer(100)->locale('es')->toLetters();
+
+// Floating-point numbers, this method strictly requires a string value as an argument.
+SpellNumber::float('12345.23')->locale('es')->toLetters();
 ```
 
 ## Creator
+
 - 🇨🇴 Raúl Mauricio Uñate Castro
 - Email: raulmauriciounate@gmail.com
 
+## Contributors
+Farsi language:
+- <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Profile Image" width="30" style="border-radius: 50%;">
+  [Siros Fakhri](https://github.com/sirosfakhri)
+
 ## License
-This project is under the [MIT License](https://choosealicense.com/licenses/mit/).
+
+This project is licensed under the [MIT License](https://choosealicense.com/licenses/mit/).

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 
 ## Contributors
 Farsi language:
-- <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Profile Image" width="30" style="border-radius: 50%;">
-  [Siros Fakhri](https://github.com/sirosfakhri)
+
+<img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Profile Image" width="30" style="border-radius: 50%;">[Siros Fakhri](https://github.com/sirosfakhri)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 - Email: raulmauriciounate@gmail.com
 
 ## Contributors
-[![Imagen de perfil](https://avatars.githubusercontent.com/u/56381478?v=4){: width="40" height="40" style="border-radius: 50%;"}](https://github.com/sirosfakhri)
-[Siros Fakhri](https://github.com/sirosfakhri)
+[Siros Fakhri](https://github.com/sirosfakhri) (Farsi Language)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 - Email: raulmauriciounate@gmail.com
 
 ## Contributors
-<a href="https://github.com/sirosfakhri">
-    <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="40" height="40" style="border-radius: 50%;">
-</a>
+[![Imagen de perfil](https://avatars.githubusercontent.com/u/56381478?v=4){: width="40" height="40" style="border-radius: 50%;"}](https://github.com/sirosfakhri)
 [Siros Fakhri](https://github.com/sirosfakhri)
 
 ## License

--- a/README_SPANISH.md
+++ b/README_SPANISH.md
@@ -107,8 +107,8 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 
 ## Contribuidores
 Idioma Farsi
-- <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="30" style="border-radius: 50%;">
-  [Siros Fakhri](https://github.com/sirosfakhri)
+
+<img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="30" style="border-radius: 50%;">[Siros Fakhri](https://github.com/sirosfakhri)
 
 ## Licencia
 

--- a/README_SPANISH.md
+++ b/README_SPANISH.md
@@ -106,8 +106,7 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 - Correo electrónico: raulmauriciounate@gmail.com
 
 ## Contribuidores
-[![Imagen de perfil](https://avatars.githubusercontent.com/u/56381478?v=4){: width="40" height="40" style="border-radius: 50%;"}](https://github.com/sirosfakhri)
-[Siros Fakhri](https://github.com/sirosfakhri)
+[Siros Fakhri](https://github.com/sirosfakhri) (Idioma Farsi)
 
 ## Licencia
 

--- a/README_SPANISH.md
+++ b/README_SPANISH.md
@@ -106,9 +106,7 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 - Correo electrónico: raulmauriciounate@gmail.com
 
 ## Contribuidores
-<a href="https://github.com/sirosfakhri">
-    <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="40" height="40" style="border-radius: 50%;">
-</a>
+[![Imagen de perfil](https://avatars.githubusercontent.com/u/56381478?v=4){: width="40" height="40" style="border-radius: 50%;"}](https://github.com/sirosfakhri)
 [Siros Fakhri](https://github.com/sirosfakhri)
 
 ## Licencia

--- a/README_SPANISH.md
+++ b/README_SPANISH.md
@@ -1,6 +1,6 @@
-# Convertir de números a Letras en Laravel
+# Convertir Números a Letras en Laravel
 
-Convierta fácilmente números a letras en Laravel utilizando esta biblioteca, que admite la extensión nativa PHP INTL para realizar la conversión de manera sencilla. Con esta librería, puede convertir números a letras en varios idiomas y también obtener el valor en formato de moneda según el idioma seleccionado. Los idiomas con soporte incluyen inglés, español, portugués, francés, italiano y rumano.
+Convierte fácilmente números a letras en Laravel utilizando esta biblioteca, que emplea la extensión nativa `PHP INTL` para realizar la conversión de manera sencilla. Con esta librería, puedes convertir números a letras en varios idiomas y también obtener el valor en formato de moneda según el idioma seleccionado. Los idiomas con soporte incluyen inglés, español, portugués, francés, italiano, rumano y gracias a la colaboración de [Siros Fakhri](https://github.com/sirosfakhri), también se ha agregado soporte para persa (Farsi).
 
 ⚙️ Esta librería es compatible con versiones de Laravel 8.0 y superiores ⚙️
 
@@ -11,12 +11,15 @@ Convierta fácilmente números a letras en Laravel utilizando esta biblioteca, q
 ![SpellNumbers](https://github.com/rmunate/SpellNumber/assets/91748598/f2aea68b-fc9f-46be-ae54-a4955f0ce7a2)
 
 ## Tabla de Contenidos
+
 - [Instalación](#instalación)
 - [Uso](#uso)
 - [Creador](#creador)
+- [Contribuidores](#contribuidores)
 - [Licencia](#licencia)
 
 ## Instalación
+
 Para instalar la dependencia a través de Composer, ejecuta el siguiente comando:
 
 ```shell
@@ -26,38 +29,70 @@ composer require rmunate/spell-number
 Es importante asegurarse de que la extensión `intl` esté habilitada y cargada en el entorno.
 
 ## Uso
+
 Después de instalar la dependencia en tu proyecto, puedes empezar a usarla con los siguientes ejemplos:
 
-```php
-// OBTENER LOS IDIOMAS DISPONIBLES
-SpellNumber::getAllLocales();
-// array:6 [▼ //
-//     0 => "en"
-//     1 => "es"
-//     2 => "pt"
-//     3 => "fr"
-//     4 => "it"
-//     5 => "ro"
-// ]
+#### Conocer las Configuraciones Regionales con Soporte
 
-// CONVERTIR ENTERO A LETRAS
+Para obtener el listado actual de idiomas con soporte, ejecuta el siguiente comando:
+
+```php
+SpellNumber::getAllLocales();
+// array:7 [▼
+//     0 => "en" (Inglés)
+//     1 => "es" (Español)
+//     2 => "pt" (Portugués)
+//     3 => "fr" (Francés)
+//     4 => "it" (Italiano)
+//     5 => "ro" (Rumano)
+//     6 => "fa" (Farsi)
+// ]
+```
+
+#### Convertir Números Enteros a Letras
+
+Puedes convertir fácilmente números a letras definiendo la configuración regional a aplicar. Si no defines la configuración regional, por defecto se aplicará "en" (Inglés).
+
+```php
 SpellNumber::value(100)->locale('es')->toLetters();
 // "Cien"
-SpellNumber::value(12300000)->locale('es')->toLetters();
-// "Doce Millones Trescientos Mil"
 
-// CONVERTIR FLOAT A LETRAS
+SpellNumber::value(100)->locale('fa')->toLetters();
+// "صد"
+
+SpellNumber::value(100)->locale('en')->toLetters();
+// "One Hundred"
+```
+
+#### Convertir Números de Coma Flotante
+
+Si lo necesitas, puedes enviar un número de coma flotante como argumento para convertirlo a letras.
+
+```php
 SpellNumber::value(123456789.12)->locale('es')->toLetters();
 // "Ciento Veintitrés Millones Cuatrocientos Cincuenta Y Seis Mil Setecientos Ochenta Y Nueve Con Doce"
+```
 
-// CONVERTIR ENTERO A FORMATO TEXTO MONEDA
+#### Convertir a Formato Moneda
+
+Este método puede ser útil para facturas, remisiones y similares. Obtén el valor suministrado en formato moneda.
+
+```php
 SpellNumber::value(100)->locale('es')->currency('pesos')->toMoney();
 // "Cien Pesos"
+
 SpellNumber::value(100.12)->locale('es')->currency('Pesos')->fraction('centavos')->toMoney();
 // "Cien Pesos Con Doce Centavos"
 
-// OTROS MÉTODOS DE INICIO 
+SpellNumber::value(100)->locale('fa')->currency('تومان')->toMoney();
+// "صد تومان"
+```
 
+#### Otros Métodos Inicializadores
+
+Para dar soporte a la versión 1.X, se mantienen los siguientes inicializadores.
+
+```php
 // Entero, este método requiere de forma estricta que se envíe un valor entero como argumento.
 SpellNumber::integer(100)->locale('es')->toLetters();
 
@@ -66,8 +101,15 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 ```
 
 ## Creador
+
 - 🇨🇴 Raúl Mauricio Uñate Castro
 - Correo electrónico: raulmauriciounate@gmail.com
 
+## Contribuidores
+Idioma Farsi
+- <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="30" style="border-radius: 50%;">
+  [Siros Fakhri](https://github.com/sirosfakhri)
+
 ## Licencia
+
 Este proyecto se encuentra bajo la [Licencia MIT](https://choosealicense.com/licenses/mit/).

--- a/README_SPANISH.md
+++ b/README_SPANISH.md
@@ -106,9 +106,10 @@ SpellNumber::float('12345.23')->locale('es')->toLetters();
 - Correo electrónico: raulmauriciounate@gmail.com
 
 ## Contribuidores
-Idioma Farsi
-
-<img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="30" style="border-radius: 50%;">[Siros Fakhri](https://github.com/sirosfakhri)
+<a href="https://github.com/sirosfakhri">
+    <img src="https://avatars.githubusercontent.com/u/56381478?v=4" alt="Imagen de perfil" width="40" height="40" style="border-radius: 50%;">
+</a>
+[Siros Fakhri](https://github.com/sirosfakhri)
 
 ## Licencia
 

--- a/src/Langs/Langs.php
+++ b/src/Langs/Langs.php
@@ -27,12 +27,12 @@ final class Langs
      * @var array
      */
     public const LOCALES_CONNECTORS = [
-        'en' => 'and',   // English from the United States: "and"
-        'es' => 'con',   // Spanish from Spain: "con"
-        'pt' => 'com',   // Portuguese from Portugal: "com"
-        'fr' => 'et',    // French from France: "et"
-        'it' => 'con',   // Italian from Italy: "con"
-        'ro' => 'cu',    // Romanian from Romania: "cu"
+        'en' => 'and',      // English from the United States: "and"
+        'es' => 'con',      // Spanish from Spain: "con"
+        'pt' => 'com',      // Portuguese from Portugal: "com"
+        'fr' => 'et',       // French from France: "et"
+        'it' => 'con',      // Italian from Italy: "con"
+        'ro' => 'cu',       // Romanian from Romania: "cu"
         'fa' => 'ممیز',     // Farsi from Iran: "ممیز"
     ];
 
@@ -45,10 +45,10 @@ final class Langs
         'en' => 'of',   // English from the United States: "of"
         'es' => 'de',   // Spanish from Spain: "de"
         'pt' => 'de',   // Portuguese from Portugal: "de"
-        'fr' => 'de',    // French from France: "de"
+        'fr' => 'de',   // French from France: "de"
         'it' => 'di',   // Italian from Italy: "di"
-        'ro' => 'de',    // Romanian from Romania: "de"
-        'fa' => 'از',     // Farsi from Iran: "از"
+        'ro' => 'de',   // Romanian from Romania: "de"
+        'fa' => 'از',   // Farsi from Iran: "از"
     ];
 
     /**


### PR DESCRIPTION
- Add Persian to the List of supported languages.

```php
SpellNumber::value(100)->locale('fa')->toLetters();
//صد

SpellNumber::value(100)->locale('fa')->currency('تومان')->toMoney();
//صد تومان
```

- Remove PHP 7.4 since this is only usable for PHP 8.0 and higher, since match is required PHP 8.0 and higher and is used in the files, So, I removed PHP 7.4 from composer.json because this will throw error in PHP < 8.0

- Add return type for methods

- Rename method `validateMaximun` to `validateMaximum` and replace it in all files.